### PR TITLE
Support per-service config item `allowAnyDate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * "Please supply a ..." messages come and go depending on submitted request type. Fixes PR-1717.
 * Do not assume that mod-rs's successful-POST response has a `serviceType` field. That assumption could cause an NPE under some circumstances. No Jira issue.
 * Make robust against old version of mod-rs (e.g. 2.15.5) that do not return lists of copyright types. Fixes PR-1841.
+* Support per-service config item `allowAnyDate` to disable date validation in forms. Update docs, add tests. Fixes PR-2059.
 
 ## [1.6.0](https://github.com/openlibraryenvironment/listener-openurl/tree/v1.6.0) (2024-03-04)
 

--- a/config/openurl.json
+++ b/config/openurl.json
@@ -55,7 +55,8 @@
       "okapiUrl": "https://north-okapi.folio-dev.indexdata.com",
       "tenant": "reshare_north",
       "username": "north_admin",
-      "password": "north5231"
+      "password": "north5231",
+      "allowAnyDate": true
     }
   }
 }

--- a/config/templates/form1.html
+++ b/config/templates/form1.html
@@ -196,7 +196,7 @@
               <div id="div-publicationDate" class="key-value-pair">
                 <label class="key" for="input-publicationDate">Year of publication</label>
                 <div class="value">
-                  <input class="should-validate" id="input-publicationDate" name="rft.date" value="{{'rft.date'}}" pattern="[0-9]*" aria-required="true">
+                  <input class="should-validate" id="input-publicationDate" name="rft.date" value="{{'rft.date'}}" {{{pubDateValidation}}}aria-required="true">
                   <div id="error-publicationDate" class="error"></div>
                 </div>
               </div>

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -100,6 +100,8 @@ These all contain the names of [template](#templates) to be used when generating
 
 To specify several different back-ends, provide a directory under the `services` key ([example](https://github.com/openlibraryenvironment/listener-openurl/blob/a68a71b8d2feab37e3cc24ad5444396e53668c6b/config/caliban.json#L10-L36)). Within this sub-object, each key is the identifier of a service, and the corresponding value is an object with most configuration listed above. These are used when the OpenURL resolver is accessed via a baseURL whose last path component is equal to the identifier. When the resolver is accessed using a baseURL that does not match any of the configured service identifiers, it falls back to using the default service configuration (`okapiURL` etc.) specified at the top level. `loggingCategories`, `listenPort` and `docRoot` are only valid at the top-level.
 
+If the `allowAnyDate` configuration item is set for a service, then forms that require a publication date to be entered do not insist that it consist of four digits, allowing "fuzzy" dates such as "1950s", "c1935" or "17th Century".
+
 
 ### Templates
 

--- a/src/OpenURLServer.js
+++ b/src/OpenURLServer.js
@@ -141,6 +141,7 @@ function makeFormData(ctx, query, service, valuesNotShownInForm, firstTry, npl) 
       name: x.charAt(0).toUpperCase() + x.slice(1),
       checked: x === query.svc_id || (!query.svc_id && i === 0) ? 'checked' : '',
     })),
+    pubDateValidation: ctx.state?.svcCfg?.allowAnyDate ? '' : 'pattern="[0-9]*" ',
   });
 
   const format = data.formats.filter(x => x.selected);

--- a/test/06-templates.js
+++ b/test/06-templates.js
@@ -56,14 +56,28 @@ const tests = [
   },
   {
     name: 'form1',
-    values: { json: {} },
+    values: { json: {}, pubDateValidation: 'pattern="[0-9]*" ' },
     equalToFile: 'form1.html'
   },
   {
     name: 'form2',
     values: { json: {} },
     equalToFile: 'form2.html'
-  }
+  },
+  {
+    name: 'form1',
+    values: { pubDateValidation: 'pattern="[0-9]*" ' },
+    checks: [
+      /id="input-publication-date".*pattern="\[0-9\]\*"/,
+    ]
+  },
+  {
+    name: 'form1',
+    values: {},
+    checks: [
+      /value="" data-error="Please enter year/,
+    ]
+  },
 ];
 
 describe('06. substitute into templates', () => {

--- a/test/data/templates/form1.html
+++ b/test/data/templates/form1.html
@@ -45,7 +45,7 @@
               <label class="key-value-pair is-required" for="input-publication-date">
                 <div class="key">Year of publication</div>
                 <div class="value">
-                  <input class="should-validate" id="input-publication-date" type="number" name="rft.date" value="{{'rft.date'}}" pattern="[0-9]*" data-error="Please enter year of publication" aria-describedby="input-publication-date-error" aria-required="true">
+                  <input class="should-validate" id="input-publication-date" type="number" name="rft.date" value="{{'rft.date'}}" {{{pubDateValidation}}}data-error="Please enter year of publication" aria-describedby="input-publication-date-error" aria-required="true">
                 </div>
                 <div class="error" aria-live="on">
                   <div class="error-text-positioner">


### PR DESCRIPTION
Disables date validation in forms.

Update docs, add tests.

Fixes PR-2059.