### PR TITLE
Support per-service config item `alwaysShowForm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Do not assume that mod-rs's successful-POST response has a `serviceType` field. That assumption could cause an NPE under some circumstances. No Jira issue.
 * Make robust against old version of mod-rs (e.g. 2.15.5) that do not return lists of copyright types. Fixes PR-1841.
 * Support per-service config item `allowAnyDate` to disable date validation in forms. Update docs, add tests. Fixes PR-2059.
+* Support per-service config item `alwaysShowForm` to specify that the full form always should be displayed once for confirmation even when the submitted OpenURL has complete basic metadata. Update docs. Fixes PR-2059.
 
 ## [1.6.0](https://github.com/openlibraryenvironment/listener-openurl/tree/v1.6.0) (2024-03-04)
 
@@ -67,7 +68,7 @@
 * When `svc_id` is `json`, post the patron request as usual but return a JSON summary instead of an HTML page. Fixes PR-461.
 * When prompting for pickup location, offer a dropdown of valid values obtained from ReShare. Fixes PR-572. Available from v1.3.1.
 * Consolidate OpenURL resolver configuration files. Fixes PR-681.
-* Add service entries for EAST and WEST unviersities to the configuration file. Fixes PR-677.
+* Add service entries for EAST and WEST universities to the configuration file. Fixes PR-677.
 * When a baseURL is invoked with no parameters (or insufficient to attempt a resolution), the enter-metadata form is presented. Fixes PR-651.
 * Support the `rft.edition` key. This is not mentioned in the standards, but appears in some example v1.0 OpenURLs.
 * Apply styles to the Request Accepted page. Fixes PR-686.

--- a/config/openurl.json
+++ b/config/openurl.json
@@ -56,7 +56,8 @@
       "tenant": "reshare_north",
       "username": "north_admin",
       "password": "north5231",
-      "allowAnyDate": true
+      "allowAnyDate": true,
+      "alwaysShowForm": true
     }
   }
 }

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -102,6 +102,8 @@ To specify several different back-ends, provide a directory under the `services`
 
 If the `allowAnyDate` configuration item is set for a service, then forms that require a publication date to be entered do not insist that it consist of four digits, allowing "fuzzy" dates such as "1950s", "c1935" or "17th Century".
 
+If the `alwaysShowForm` configuration item is set for a service, then the full form is always displayed once for confirmation even when the submitted OpenURL has complete basic metadata.
+
 
 ### Templates
 

--- a/src/ContextObject.js
+++ b/src/ContextObject.js
@@ -137,7 +137,7 @@ class ContextObject {
   hasBasicData() {
     const rft = (this.metadata || {}).rft || {};
     let st = this.admindata.svc?.id;
-    if (st === 'contextObject') st = 'loan';
+    if (st === 'contextObject' || !st) st = 'loan';
 
     if (this.admindata.rft?.id) return true;
     if (st === 'loan' && rft.title && rft.au) return true;


### PR DESCRIPTION
Forces the full form to be displayed once, even if all necessary metadata is present, requiring the user to confirm.

Update docs.

Fixes PR-2060.