### PR TITLE
Rename misleadingly-named `OkapiSession.logger` member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Support per-service config item `allowAnyDate` to disable date validation in forms. Update docs, add tests. Fixes PR-2059.
 * Support per-service config item `alwaysShowForm` to specify that the full form always should be displayed once for confirmation even when the submitted OpenURL has complete basic metadata. Update docs. Fixes PR-2059.
 * Add Service Level field to blank request form. Fixes PR-2056.
+* TECH DEBT: The `OkapiSession`'s config object is now in its `cfg` member, not `logger`. Fixes PR-2095.
 
 ## [1.6.0](https://github.com/openlibraryenvironment/listener-openurl/tree/v1.6.0) (2024-03-04)
 

--- a/src/OkapiSession.js
+++ b/src/OkapiSession.js
@@ -5,7 +5,7 @@ const HTTPError = require('./HTTPError');
 
 class OkapiSession {
   constructor(cfg, label = 'main', values) {
-    this.logger = cfg;
+    this.cfg = cfg;
     this.label = label;
     if (!values) values = cfg.getValues();
     if (values.withoutOkapi) return;
@@ -22,7 +22,7 @@ class OkapiSession {
 
   login() {
     const { username, password } = this;
-    this.logger.log('okapi', `logging into Okapi session '${this.label}' as ${username}/${password}`);
+    this.cfg.log('okapi', `logging into Okapi session '${this.label}' as ${username}/${password}`);
     this.token = undefined;
     return this.okapiFetch('POST', '/authn/login', { username, password }, true)
       .then(res => {
@@ -32,7 +32,7 @@ class OkapiSession {
   }
 
   async _getDataFromReShare(path, caption) {
-    if (this.logger.values?.withoutOkapi) {
+    if (this.cfg.values?.withoutOkapi) {
       // Running as part of a test: do nothing
       return {};
     }
@@ -40,7 +40,7 @@ class OkapiSession {
     const res = await this.okapiFetch('GET', path);
     if (res.status !== 200) throw new HTTPError(res, `cannot fetch default ${caption} for '${this.label}'`);
     const json = await res.json();
-    this.logger.log('json', this.label, JSON.stringify(json, null, 2));
+    this.cfg.log('json', this.label, JSON.stringify(json, null, 2));
     return json;
   }
 
@@ -92,7 +92,7 @@ class OkapiSession {
       'x-okapi-tenant': this.tenant,
     };
     if (this.token) headers['x-okapi-token'] = this.token;
-    this.logger.log('okapi', `okapiFetch ${method} for session '${this.label}' at ${path}`);
+    this.cfg.log('okapi', `okapiFetch ${method} for session '${this.label}' at ${path}`);
     return fetch(`${this.okapiUrl}${path}`, {
       method,
       body: payload ? JSON.stringify(payload) : undefined,


### PR DESCRIPTION
TECH DEBT: The `OkapiSession`'s config object is now in its `cfg` member, not `logger`.

We got away with this weirdness until recently because the only thing the Okapi session used its config object for was logging.

Fixes PR-2095.