### PR TITLE
Non-modal API for fetching vocabs from ReShare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Add Service Level field to blank request form. Fixes PR-2056.
 * Add maximum cost field-pair (`maximumCostsMonetaryValue` and `maximumCostsCurrencyCode`) to blank request form. Fixes PR-2058.
 * TECH DEBT: The `OkapiSession`'s config object is now in its `cfg` member, not `logger`. Fixes PR-2095.
+* TECH DEBT: Change modal API for fetching controlled vocabularies to one that returns the fetched data. Fixes PR-2097.
 
 ## [1.6.0](https://github.com/openlibraryenvironment/listener-openurl/tree/v1.6.0) (2024-03-04)
 

--- a/src/OkapiSession.js
+++ b/src/OkapiSession.js
@@ -44,7 +44,8 @@ class OkapiSession {
     return json;
   }
 
-  async getPickupLocations() {
+  async listPickupLocations() {
+    // XXX could no-op if this.pickupLocations is already defined
     const path = '/directory/entry?filters=tags.value%3Di%3Dpickup&filters=status.value%3Di%3Dmanaged&perPage=100&stats=true';
     const json = await this._getDataFromReShare(path, 'pickup locations');
     this.pickupLocations = json.results
@@ -57,6 +58,8 @@ class OkapiSession {
         if (typeof b.name !== 'string') return -1;
         return a.name.localeCompare(b.name);
       });
+
+    return this.pickupLocations;
   }
 
   async _getRefDataValues(desc, caption) {
@@ -65,25 +68,30 @@ class OkapiSession {
     return json[0]?.values.map(r => ({ id: r.id, code: r.value, name: r.label }));
   }
 
-  async getCopyrightTypes() {
+  async listCopyrightTypes() {
     // XXX could no-op if this.copyrightTypes is already defined
     this.copyrightTypes = await this._getRefDataValues('copyrightType', 'copyright types');
+    return this.copyrightTypes;
   }
 
-  async getServiceLevels() {
+  async listServiceLevels() {
     // XXX could no-op if this.serviceLevels is already defined
     this.serviceLevels = await this._getRefDataValues('ServiceLevels', 'service levels');
+    return this.serviceLevels;
   }
 
-  async getCurrencies() {
+  async listCurrencies() {
     // XXX could no-op if this.currencies is already defined
     this.currencies = await this._getRefDataValues('CurrencyCodes', 'currencies');
+    return this.currencies;
   }
 
-  async getDefaultCopyrightType() {
+  async listDefaultCopyrightType() {
+    // XXX could no-op if this.defaultCopyrightType is already defined
     const path = '/rs/settings/appSettings?filters=section%3D%3Dother&filters=key%3D%3Ddefault_copyright_type&perPage=1';
     const json = await this._getDataFromReShare(path, 'default copyright type');
     this.defaultCopyrightType = json[0]?.value;
+    return this.defaultCopyrightType;
   }
 
   post(path, payload) {


### PR DESCRIPTION
TECH DEBT: Change modal API for fetching controlled vocabularies to one that returns the fetched data.

Fixes PR-2097.