### PR TITLE
Sort downloaded vocabularies alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Add maximum cost field-pair (`maximumCostsMonetaryValue` and `maximumCostsCurrencyCode`) to blank request form. Fixes PR-2058.
 * TECH DEBT: The `OkapiSession`'s config object is now in its `cfg` member, not `logger`. Fixes PR-2095.
 * TECH DEBT: Change modal API for fetching controlled vocabularies to one that returns the fetched data. Fixes PR-2097.
+* When loading controlled vocabaries from ReShare for the form, default to sorting alphabetically. Fixes PR-2201.
 
 ## [1.6.0](https://github.com/openlibraryenvironment/listener-openurl/tree/v1.6.0) (2024-03-04)
 

--- a/src/OkapiSession.js
+++ b/src/OkapiSession.js
@@ -63,9 +63,10 @@ class OkapiSession {
   }
 
   async _getRefDataValues(desc, caption) {
-    const path = `/rs/refdata?filters=desc%3D%3D${desc}&sort=desc%3Basc&max=100`;
+    const path = `/rs/refdata?filters=desc%3D%3D${desc}&max=100`;
     const json = await this._getDataFromReShare(path, caption);
-    return json[0]?.values.map(r => ({ id: r.id, code: r.value, name: r.label }));
+    return json[0]?.values.map(r => ({ id: r.id, code: r.value, name: r.label }))
+      .sort((a, b) => a.name.localeCompare(b.name));
   }
 
   async listCopyrightTypes() {

--- a/src/OpenURLServer.js
+++ b/src/OpenURLServer.js
@@ -122,7 +122,6 @@ async function makeFormData(ctx, query, service, valuesNotShownInForm, firstTry,
   const res = await Promise.all(promises);
   const [serviceLevels, currencies, copyrightTypes, pickupLocations, defaultCopyrightType] = res;
   const currentCopyrightType = query['rft.copyrightType'] || defaultCopyrightType;
-  console.error('defaultCopyrightType =', defaultCopyrightType, '-- currentCopyrightType =', currentCopyrightType);
 
   const data = Object.assign({}, query, {
     valuesNotShownInForm,


### PR DESCRIPTION
When loading controlled vocabaries from ReShare for the form, default to sorting alphabetically.

Fixes PR-2201.