### PR TITLE
Fix a typo that probably affected copyright-types dropdown

### DIFF
--- a/src/OpenURLServer.js
+++ b/src/OpenURLServer.js
@@ -319,7 +319,7 @@ async function postReshareRequest(ctx, next) {
     if (vars.isCopy) {
       let copyrightTypes = ctx.cfg.getValues()?.copyrightTypes;
       if (!copyrightTypes) {
-        copyrighttypes = await service.listCopyrightTypes();
+        copyrightTypes = await service.listCopyrightTypes();
       }
       // XXX It should not be necessary to consult the request we sent, this should be in the response
       const ct = find(copyrightTypes, x => x.code === rreq.copyrightType?.value);


### PR DESCRIPTION
copyrighttypes -> copyrightTypes

In context, this _has_ to be a typo, right? Compare with the code that we had here before, as seen in the old code in the diff of 389b8647b98c80a385a728500e9a4aae608e2e30